### PR TITLE
Generic open functions

### DIFF
--- a/wavespectra/input/__init__.py
+++ b/wavespectra/input/__init__.py
@@ -59,9 +59,7 @@ def open_netcdf(filename_or_fileglob, chunks):
     Args:
         - filename_or_fileglob (str, list, fileobj): filename, fileglob specifying
           multiple files, or fileobj to read.
-        - chunks (dict): chunk sizes for dimensions in dataset. By default
-          dataset is loaded using single chunk for all dimensions (see
-          xr.open_mfdataset documentation).
+        - chunks (dict): chunk sizes for dimensions in dataset.
 
     Returns:
         - dset (Dataset): spectra dataset object read from netcdf file.
@@ -101,3 +99,24 @@ def open_netcdf_or_zarr(filename_or_fileglob, file_format, mapping={}, chunks={}
     else:
         raise ValueError("file_format must be one of ('netcdf', 'zarr')")
     return dset
+
+
+def read_ascii_or_binary(file, mode="r"):
+    """Read content from ascii or binary file.
+
+    Args:
+        - file (str, fileobj): Name of file or file object to read.
+        - mode (str): Mode to open file, one of 'r', 'rb'.
+
+    Returns:
+        - data (list): List of lines read from file.
+
+    """
+    try:
+        data = file.readlines()
+    except AttributeError:
+        if mode not in ["r", "rb"]:
+            raise ValueError("mode must be one of 'r', 'rb'")
+        with open(file, mode) as stream:
+            data = stream.readlines()
+    return data

--- a/wavespectra/input/__init__.py
+++ b/wavespectra/input/__init__.py
@@ -48,12 +48,40 @@ def chunks_dict(chunks, mapping):
     return _chunks
 
 
+def open_netcdf(filename_or_fileglob, chunks):
+    """Open netcdf file.
+
+    Netcdf files are attempted to be open with xr.open_mfdataset first to handle either
+    single or multiple files. However, this function does not support file-like
+    objects, so if an error is raised, we assume a file-like object is passed and open
+    it directly with xr.open_dataset.
+
+    Args:
+        - filename_or_fileglob (str, list, fileobj): filename, fileglob specifying
+          multiple files, or fileobj to read.
+        - chunks (dict): chunk sizes for dimensions in dataset. By default
+          dataset is loaded using single chunk for all dimensions (see
+          xr.open_mfdataset documentation).
+
+    Returns:
+        - dset (Dataset): spectra dataset object read from netcdf file.
+
+    """
+    try:
+        dset = xr.open_mfdataset(
+            filename_or_fileglob, chunks=chunks, combine="by_coords"
+        )
+    except (ValueError, IndexError):
+        dset = xr.open_dataset(filename_or_fileglob, chunks=chunks)
+    return dset
+
+
 def open_netcdf_or_zarr(filename_or_fileglob, file_format, mapping={}, chunks={}):
     """Read spectra dataset in either netcdf or zarr format.
 
     Args:
-        - filename_or_fileglob (str, list, fileobj): filename, fileglob specifying multiple
-          files, or fileobj to read.
+        - filename_or_fileglob (str, list, fileobj): filename, fileglob specifying
+          multiple files, or fileobj to read.
         - file_format (str): format of file to open, one of `netcdf` or `zarr`.
         - mapping (dict): coordinates mapping from original dataset to wavespectra.
         - chunks (dict): chunk sizes for dimensions in dataset. By default
@@ -61,23 +89,13 @@ def open_netcdf_or_zarr(filename_or_fileglob, file_format, mapping={}, chunks={}
           xr.open_mfdataset documentation).
 
     Returns:
-        - dset (Dataset): spectra dataset object read from ww3 file.
+        - dset (Dataset): spectra dataset object read from netcdf or zarr file.
 
     """
     # Allow chunking using wavespectra names
     _chunks = chunks_dict(chunks, mapping)
     if file_format == "netcdf":
-        # Use mfdataset to open if a filename or fileglob is passed
-        # otherwise we assume a fileobj is passed and open it directly with
-        # xr.open_dataset
-        try:
-            dset = xr.open_mfdataset(
-                filename_or_fileglob, chunks=_chunks, combine="by_coords"
-            )
-        # TODO: Some inconsistency in how xarray handles fileobjs between different
-        # versions. For now use a catch all.
-        except Exception:
-            dset = xr.open_dataset(filename_or_fileglob, chunks=_chunks)
+        dset = open_netcdf(filename_or_fileglob, _chunks)
     elif file_format == "zarr":
         dset = xr.open_zarr(filename_or_fileglob, consolidated=True, chunks=_chunks)
     else:

--- a/wavespectra/input/funwave.py
+++ b/wavespectra/input/funwave.py
@@ -3,6 +3,7 @@ import numpy as np
 import xarray as xr
 
 from wavespectra import SpecArray
+from wavespectra.input import read_ascii_or_binary
 from wavespectra.core.attributes import attrs, set_spec_attributes
 
 
@@ -22,11 +23,7 @@ def read_funwave(filename_or_obj):
         - Phases are ignored if present.
 
     """
-    try:
-        data = filename_or_obj.readlines()
-    except AttributeError:
-        with open(filename_or_obj, "r") as f:
-            data = f.readlines()
+    data = read_ascii_or_binary(filename_or_obj, mode="r")
 
     # Remove any empty rows
     data = [row for row in data if row != "\n"]

--- a/wavespectra/input/ndbc.py
+++ b/wavespectra/input/ndbc.py
@@ -27,7 +27,7 @@ def read_ndbc(url, directional=True, dd=10.0, chunks={}):
     """Read Spectra from NDBC netCDF format.
 
     Args:
-        - url (str): Thredds URL or local path of file to read.
+        - url (str): Thredds URL or local path of file or fileobj to read.
         - directional (bool): Constructs 2D spectra if True, returns 1D if False.
         - dd (float): Directional resolution for 2D spectra (deg).
         - chunks (dict): Chunk sizes for dimensions in dataset. By default

--- a/wavespectra/input/ndbc_ascii.py
+++ b/wavespectra/input/ndbc_ascii.py
@@ -114,7 +114,8 @@ def read_ndbc_ascii(filename, dirs=np.arange(0, 360, 10)):
     elif isinstance(filename, list):
         if not len(filename) == 5:
             raise ValueError(
-                "filename argument for NDBC directional spectra must be list with 5 files [spden,swdir,swdir2,swr1,swr2]"
+                "filename argument for NDBC directional spectra must be "
+                "a list with 5 files [spden, swdir, swdir2, swr1, swr2]"
             )
     else:
         raise TypeError("filename argument must be string, path or list")

--- a/wavespectra/input/netcdf.py
+++ b/wavespectra/input/netcdf.py
@@ -2,6 +2,7 @@
 import xarray as xr
 
 from wavespectra.specdataset import SpecDataset
+from wavespectra.input import open_netcdf
 from wavespectra.core.attributes import attrs, set_spec_attributes
 
 
@@ -37,12 +38,7 @@ def read_netcdf(
           'time' and/or 'station' dims.
 
     """
-    try:
-        dset = xr.open_mfdataset(
-            filename_or_fileglob, chunks=chunks, combine="by_coords"
-        )
-    except ValueError:
-        dset = xr.open_dataset(filename_or_fileglob)
+    dset = open_netcdf(filename_or_fileglob, chunks=chunks)
     coord_map = {
         freqname: attrs.FREQNAME,
         dirname: attrs.DIRNAME,

--- a/wavespectra/input/wavespectra.py
+++ b/wavespectra/input/wavespectra.py
@@ -10,8 +10,8 @@ def read_wavespectra(filename_or_fileglob, file_format="netcdf", chunks={}):
     """Read Spectra from from netCDF or ZARR format in Wavespectra convention.
 
     Args:
-        - filename_or_fileglob (str, list, fileobj): filename, fileglob specifying multiple
-          files, or a file object to read.
+        - filename_or_fileglob (str, list, fileobj): filename, fileglob specifying
+          multiple files, or a file object to read.
         - file_format (str): format of file to open, one of `netcdf` or `zarr`.
         - chunks (dict): chunk sizes for dimensions in dataset. By default
           dataset is loaded using single chunk for all dimensions (see

--- a/wavespectra/input/ww3.py
+++ b/wavespectra/input/ww3.py
@@ -24,8 +24,8 @@ def read_ww3(filename_or_fileglob, file_format="netcdf", mapping=MAPPING, chunks
     """Read Spectra from WAVEWATCHIII native netCDF format.
 
     Args:
-        - filename_or_fileglob (str, list, fileobj): filename, fileglob specifying multiple
-          files, or a file object to read.
+        - filename_or_fileglob (str, list, fileobj): filename, fileglob specifying
+          multiple files, or a file object to read.
         - file_format (str): format of file to open, one of `netcdf` or `zarr`.
         - mapping (dict): coordinates mapping from original dataset to wavespectra.
         - chunks (dict): chunk sizes for dimensions in dataset. By default

--- a/wavespectra/input/ww3_station.py
+++ b/wavespectra/input/ww3_station.py
@@ -5,6 +5,7 @@ import numpy as np
 import xarray as xr
 
 from wavespectra.core.attributes import attrs, set_spec_attributes
+from wavespectra.input import read_ascii_or_binary
 from wavespectra.core.utils import D2R, R2D
 
 
@@ -26,18 +27,15 @@ def extract_direction(dir):
 
 def read_ww3_station(filename_or_fileglob):
     """Read directional spectra from WW3 station output file.
+
     Args:
         - filename_or_fileglob (str, filelike): filename or file object to read.
 
     Returns:
         - dset (SpecDataset): spectra dataset object read from
-        WW3 station output file.
+          WW3 station output file.
     """
-    try:
-        lines = filename_or_fileglob.readlines()
-    except AttributeError:
-        with open(filename_or_fileglob, "r") as f:
-            lines = f.readlines()
+    lines = read_ascii_or_binary(filename_or_fileglob, mode="r")
 
     header = lines.pop(0)
     header_regex = re.compile(HEADER_REGEX_STR)

--- a/wavespectra/input/wwm.py
+++ b/wavespectra/input/wwm.py
@@ -25,8 +25,8 @@ def read_wwm(filename_or_fileglob, file_format="netcdf", mapping=MAPPING, chunks
     """Read Spectra from WWMII native netCDF format.
 
     Args:
-        - filename_or_fileglob (str, list, fileobj): filename, fileglob specifying multiple
-          files, or a file object to read.
+        - filename_or_fileglob (str, list, fileobj): filename, fileglob specifying
+          multiple files, or a file object to read.
         - file_format (str): format of file to open, one of `netcdf` or `zarr`.
         - mapping (dict): coordinates mapping from original dataset to wavespectra.
         - chunks (dict): chunk sizes for dimensions in dataset. By default


### PR DESCRIPTION
@mpiannucci sorry for taking a bit long to get back on this. You have done a great effort to implement the fileobj capability, having reviewed the different readers I realise it is not going to be trivial to support every single reading function in wavespectra as some deal in its own ways with the file objects. What you have done however covers already many of these functions, and more importantly the file types that are likely to be provided as a fileobj so I suggest we go ahead and merge it and perhaps take care of the remaining ones later on if there is need for that.

This current merge request implements a few changes to what you have done. I moved the netcdf opening logic into a new function so it can be used by other readers (such as wavespectra.input.netcdf.open_netcdf for instance). I haven't managed to get an IndexError as I mentioned I got earlier (not sure if xarray version issue or something else) so I changed the generic exception into (ValueError, IndexError) to cover only these two cases.

I also created a new generic opener to read the content of ascii or binary files. We can't use it in all ascii readers at the moment thought since some require the fileobj itself and not the full content in a list.

If you are happy please merge this onto your branch and I'll merge your pull request afterwards.